### PR TITLE
fix build error, missed std::memcpy function

### DIFF
--- a/src/lib/QHexView/QHexView.cpp
+++ b/src/lib/QHexView/QHexView.cpp
@@ -23,7 +23,7 @@ QHexView::QHexView(QWidget *parent) :
         m_pdata(NULL) {
     setFont(QFont("Courier", 10));
 
-#if QT_VERSION >= 0x051100
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
     m_charWidth = fontMetrics().horizontalAdvance(QLatin1Char('9'));
 #else
     m_charWidth = fontMetrics().width(QLatin1Char('9'));
@@ -100,7 +100,7 @@ QSize QHexView::fullSize() const {
 }
 
 void QHexView::updatePositions() {
-#if QT_VERSION >= 0x051100
+#if QT_VERSION >= QT_VERSION_CHECK(5,11,0)
     m_charWidth = fontMetrics().horizontalAdvance(QLatin1Char('9'));
 #else
     m_charWidth = fontMetrics().width(QLatin1Char('9'));

--- a/src/spi_nand.cpp
+++ b/src/spi_nand.cpp
@@ -14,6 +14,7 @@
 
 #include <QMessageBox>
 #include <QFontDatabase>
+#include <cstring>
 
 #include "spi_nand.h"
 #include "x.h"


### PR DESCRIPTION
[ 52%] Building CXX object CMakeFiles/YFEL.dir/spi_nand.cpp.o /home/kunyi/Allwinner/YFEL/src/spi_nand.cpp: In member function ‘void spi_nand::spi_nand_write(uint32_t, const uint8_t*, uint32_t)’: /home/kunyi/Allwinner/YFEL/src/spi_nand.cpp:379:22: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  379 |                 std::memcpy(&txbuf[txlen], buf, n);
      |                      ^~~~~~
      |                      wmemcpy
make[2]: *** [CMakeFiles/YFEL.dir/build.make:195: CMakeFiles/YFEL.dir/spi_nand.cpp.o] Error 1